### PR TITLE
Call compress ice after ice_ridging to clean up any residual part siz…

### DIFF
--- a/src/SIS_transport.F90
+++ b/src/SIS_transport.F90
@@ -263,6 +263,8 @@ subroutine finish_ice_transport(CAS, IST, TrReg, G, US, IG, dt, CS, rdg_rate)
   if (CS%do_ridging) then
     ! Compress the ice using the ridging scheme taken from the CICE-Icepack module
     call ice_ridging(IST, G, IG, CAS%m_ice, CAS%m_snow, CAS%m_pond, TrReg, US, dt, IST%rdg_rate)
+    ! Clean up any residuals
+    call compress_ice(IST%part_size, IST%mH_ice, IST%mH_snow, IST%mH_pond, TrReg, G, US, IG, CS, CAS)
   else
 
   ! Compress the ice where the fractional coverage exceeds 1, starting with the

--- a/src/ice_ridge.F90
+++ b/src/ice_ridge.F90
@@ -444,11 +444,6 @@ subroutine ice_ridging(IST, G, IG, mca_ice, mca_snow, mca_pond, TrReg, US, dt, r
 
       endif ! have tracers to unload
 
-      if (sum(aicen(1:nCat))>1.0) then
-        call SIS_error(WARNING,'Ice cover exceeds 1 after call to ice ridge. Renormalizing.')
-        aicen(1:ncat)=aicen(1:ncat)/sum(aicen(1:ncat))
-      endif
-
       ! ! output: snow/ice masses/thicknesses
       do k=1,nCat
 


### PR DESCRIPTION
Follow suggestion from @Hallberg-NOAA of calling compress_ice after ridging in order to clean up small residual excess part sizes returned from  Icepack. 